### PR TITLE
複数のURLパラメータを同時に扱えるよう修正

### DIFF
--- a/src/components/CopyButton.vue
+++ b/src/components/CopyButton.vue
@@ -1,0 +1,63 @@
+<template>
+  <div class="buttons">
+    <div class="copyButton">
+      <button @click="copyUrlToClipboard">URLをコピー</button>
+    </div>
+    <div class="clearButton">
+      <button @click="clearParams">初期化</button>
+    </div>
+  </div>
+</template>
+
+<script>
+
+export default {
+  name: 'CopyButton',
+  components: {},
+  props: {},
+  methods: {
+    // 現在のURLをクリップボードにコピー
+    async copyUrlToClipboard() {
+      const url = window.location.href;
+      try {
+        await navigator.clipboard.writeText(url);
+        alert("現在のグラフをクリップボードにコピーしました: " + url);
+      } catch (error) {
+        console.error("URLのコピーに失敗しました: ", error);
+      }
+    },
+    // URLパラメータ削除
+    clearParams() {
+      const currentUrl = new URL(window.location.href);
+      currentUrl.search = "";
+      window.location.href = currentUrl.toString();
+    }
+  },
+}
+</script>
+
+<style scoped>
+.buttons {
+  display: flex;
+  justify-content: center;
+}
+
+.copyButton, .clearButton {
+  margin: 0 10px;
+}
+
+button {
+  background-color: #98c0ff;
+  color: #111;
+  border: none;
+  border-radius: 5px;
+  padding: 10px 20px;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+button:hover {
+  color: #fff;
+  background-color: #0069d9;
+}
+</style>

--- a/src/components/TotalPlan.vue
+++ b/src/components/TotalPlan.vue
@@ -12,6 +12,7 @@
         -->
         </div>
       </div>
+      <CopyButton />
 
       <h2>基本項目（物件購入前の資金状況確認用）</h2>
       <div class="sliders-explain">
@@ -225,12 +226,14 @@
 
 <script>
 import BarChart from './BarChart.vue';
+import CopyButton from './CopyButton.vue';
 import Lib from '../lib/lib.js';
 
 export default {
   name: 'totalPlan',
   components: {
-    BarChart
+    BarChart,
+    CopyButton
   },
   props: {
     repareReserveMonthlyDefault: String,
@@ -263,31 +266,31 @@ export default {
   watch: {
     // dataの値が変更されたときにURLパラメータを更新
     reparereservemonthly(newVal) {
-      this.$router.replace({ query: { rsm: newVal } });
+      this.$router.replace({ query: { rsm: newVal, nh: this.numberhouses, oi: this.outgointerval, cppa: this.constructionpriceperarea, raa: this.roomareaave, f: this.floors, fv: this.firstvalue, tm: this.temporarymoney, nc: this.nextconstruction } });
     },
     numberhouses(newVal) {
-      this.$router.replace({ query: { nh: newVal } });
+      this.$router.replace({ query: { rsm: this.reparereservemonthly, nh: newVal, oi: this.outgointerval, cppa: this.constructionpriceperarea, raa: this.roomareaave, f: this.floors, fv: this.firstvalue, tm: this.temporarymoney, nc: this.nextconstruction } });
     },
     outgointerval(newVal) {
-      this.$router.replace({ query: { oi: newVal } });
+      this.$router.replace({ query: { rsm: this.reparereservemonthly, nh: this.numberhouses, oi: newVal, cppa: this.constructionpriceperarea, raa: this.roomareaave, f: this.floors, fv: this.firstvalue, tm: this.temporarymoney, nc: this.nextconstruction } });
     },
     constructionpriceperarea(newVal) {
-      this.$router.replace({ query: { cppa: newVal } });
+      this.$router.replace({ query: { rsm: this.reparereservemonthly, nh: this.numberhouses, oi: this.outgointerval, cppa: newVal, raa: this.roomareaave, f: this.floors, fv: this.firstvalue, tm: this.temporarymoney, nc: this.nextconstruction } });
     },
     roomareaave(newVal) {
-      this.$router.replace({ query: { raa: newVal } });
+      this.$router.replace({ query: { rsm: this.reparereservemonthly, nh: this.numberhouses, oi: this.outgointerval, cppa: this.constructionpriceperarea, raa: newVal, f: this.floors, fv: this.firstvalue, tm: this.temporarymoney, nc: this.nextconstruction } });
     },
     floors(newVal) {
-      this.$router.replace({ query: { f: newVal } });
+      this.$router.replace({ query: { rsm: this.reparereservemonthly, nh: this.numberhouses, oi: this.outgointerval, cppa: this.constructionpriceperarea, raa: this.roomareaave, f: newVal, fv: this.firstvalue, tm: this.temporarymoney, nc: this.nextconstruction } });
     },
     firstvalue(newVal) {
-      this.$router.replace({ query: { fv: newVal } });
+      this.$router.replace({ query: { rsm: this.reparereservemonthly, nh: this.numberhouses, oi: this.outgointerval, cppa: this.constructionpriceperarea, raa: this.roomareaave, f: this.floors, fv: newVal, tm: this.temporarymoney, nc: this.nextconstruction } });
     },
     temporarymoney(newVal) {
-      this.$router.replace({ query: { tm: newVal } });
+      this.$router.replace({ query: { rsm: this.reparereservemonthly, nh: this.numberhouses, oi: this.outgointerval, cppa: this.constructionpriceperarea, raa: this.roomareaave, f: this.floors, fv: this.firstvalue, tm: newVal, nc: this.nextconstruction } });
     },
     nextconstruction(newVal) {
-      this.$router.replace({ query: { nc: newVal } });
+      this.$router.replace({ query: { rsm: this.reparereservemonthly, nh: this.numberhouses, oi: this.outgointerval, cppa: this.constructionpriceperarea, raa: this.roomareaave, f: this.floors, fv: this.firstvalue, tm: this.temporarymoney, nc: newVal } });
     },
     // URLパラメータからdataの初期値を設定
     $route: {
@@ -396,18 +399,18 @@ export default {
     // 年毎の残高
     getYearlyCosts: function () {
       // 収入
-      var incomeArray1 = Lib.getYearlyCostsArray(2022, 2060, this.getIncomeYealy / 1000, 1, 0);
-      var incomeArray2 = Lib.getYearlyCostsArray(2022, 2060, this.getTotalTemporaryMoney / 1000, 40, 41);
-      var incomeArray = Lib.getAddedArray(2022, 2060, incomeArray1, incomeArray2);
+      var incomeArray1 = Lib.getYearlyCostsArray(2022, 2062, this.getIncomeYealy / 1000, 1, 0);
+      var incomeArray2 = Lib.getYearlyCostsArray(2022, 2062, this.getTotalTemporaryMoney / 1000, 40, 38);
+      var incomeArray = Lib.getAddedArray(2022, 2062, incomeArray1, incomeArray2);
       // 支出
-      var outgoArray1 = Lib.getYearlyCostsArray(2022, 2060, this.getConstructionPrice / 1000, this.outgointerval, this.nextconstruction);
-      var outgoArray2 = Lib.getYearlyCostsArray(2022, 2060, this.getYearlyPriceWithoutLargeConstruction / 1000, 1, 0);
-      var outgoArray = Lib.getAddedArray(2022, 2060, outgoArray1, outgoArray2);
+      var outgoArray1 = Lib.getYearlyCostsArray(2022, 2062, this.getConstructionPrice / 1000, this.outgointerval, this.nextconstruction);
+      var outgoArray2 = Lib.getYearlyCostsArray(2022, 2062, this.getYearlyPriceWithoutLargeConstruction / 1000, 1, 0);
+      var outgoArray = Lib.getAddedArray(2022, 2062, outgoArray1, outgoArray2);
       // 収支
-      var years = Lib.getSubedArray(2022, 2060, incomeArray, outgoArray);
-      var balance = Lib.getBalanceArray(2022, 2060, years, this.firstvalue);
+      var years = Lib.getSubedArray(2022, 2062, incomeArray, outgoArray);
+      var balance = Lib.getBalanceArray(2022, 2062, years, this.firstvalue);
       return {
-        labels: Lib.getYearsArray(2022, 2060),
+        labels: Lib.getYearsArray(2022, 2062),
         datasets: [{ data: balance }]
       }
     }
@@ -447,6 +450,7 @@ h3 {
 .totalGraph {
   margin: 0 0 30px 0;
 }
+
 .totalGraphBody {
   max-width: 1000px;
   margin: 0 auto;

--- a/src/lib/lib.js
+++ b/src/lib/lib.js
@@ -94,7 +94,7 @@ function getBalanceArray(start, end, costArr, firstValue) {
     var span = end - start;
     years.push(firstValue);
     for (var i = 1; i <= span; i++) {
-        years.push(years[i - 1] + costArr[i]);
+        years.push(Number(years[i - 1]) + Number(costArr[i]));
     }
     return years;
 }

--- a/src/lib/lib.ts
+++ b/src/lib/lib.ts
@@ -96,7 +96,7 @@ function getBalanceArray(start: number, end: number, costArr: number[], firstVal
     let span = end - start
     years.push(firstValue);
     for (let i = 1; i <= span; i++) {
-        years.push(years[i - 1] + costArr[i]);
+        years.push(Number(years[i - 1]) + Number(costArr[i]));
     }
     return years
 }


### PR DESCRIPTION
戸数など一部のパラメータで数値が狂う（オーバーフローして特大の数値となる）現象の解消
複数パラメータを同時に扱えるようにする
URLコピーボタン、クリアボタンを設置
40年分のarray計算が行われるようにする（38年分だった）
<img width="1046" alt="スクリーンショット 2023-04-10 22 24 30" src="https://user-images.githubusercontent.com/1812140/230909596-c9e8451a-2a91-48e5-a742-7053c0a68287.png">
<img width="1045" alt="スクリーンショット 2023-04-10 22 24 36" src="https://user-images.githubusercontent.com/1812140/230909616-39d1a1e7-af7d-4b05-bb39-7d602e98eb8c.png">
<img width="538" alt="スクリーンショット 2023-04-10 22 24 45" src="https://user-images.githubusercontent.com/1812140/230909628-12cf0d49-431c-457e-bdef-4527ef1393cd.png">

